### PR TITLE
Add 3 queries and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Return all targets that have been marked as High Value.
 ### All Owned Principals
 Return all the principals that have been marked as Owned.
 
+### Group Delegated Outbound Object Control of Owned Principals
+Return Outbound Object Control (also group-delegated) of all owned principals.
+
+### Find Dangerous Rights for Groups under Domain Users
+Find groups under Domain Users which have dangerous privileges over other objects.
+
+Similar to the pre-built query "Find Dangerous Rights for Domain Users Groups", except that it includes groups nested under Domain Users.
+
 ### All Users with Password in AD
 Return all the users with a password in the AD object, can then be read in the Node Info.
 
@@ -154,6 +162,9 @@ Mark all the principals that are local administrators or that can reset password
 
 ### Set Principals with Privileges on Computers as High Value Targets
 Mark all the principals with certain privileges on computers as High Value.
+
+### Set Principals with Privileges on Cert Publishers as High Value Targets
+Mark all the principals with certain privileges on the Cert Publishers group as High Value.
 
 ### Set Members of High Value Targets Groups as High Value Targets
 Mark all the members of High Value groups as High Value.

--- a/customqueries.json
+++ b/customqueries.json
@@ -216,6 +216,24 @@
             ]
         },
         {
+            "name": "Group Delegated Outbound Object Control of Owned Principals",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH p = (n {owned: true})-[r1:MemberOf*1..]->(g:Group)-[r2 {isacl: true}]->(n) RETURN p"
+                }
+            ]
+        },
+        {
+            "name": "Find Dangerous Rights for Groups under Domain Users",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH p=(m:Group)-[r1:MemberOf*1..]->(g:Group)-[:Owns|WriteDacl|GenericAll|WriteOwner|ExecuteDCOM|GenericWrite|AllowedToDelegate|ForceChangePassword]->(n:Computer) WHERE m.objectid ENDS WITH '-513' RETURN p"
+                }
+            ]
+        },
+        {
             "name": "All Users with Password in AD",
             "queryList": [
                 {
@@ -256,7 +274,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (s)-[r:MemberOf|GetChanges*1..]->(d:Domain) WITH s, d MATCH (s)-[r:MemberOf|GetChangesAll*1..]->(d) WITH s, d MATCH p = (s)-[r:MemberOf|GetChanges|GetChangesAll*1..]->(d) SET s.highvalue = true, s.highvaluereason = 'DCSync Principal' RETURN p"
+                    "query": "MATCH (s)-[r:MemberOf|GetChanges*1..]->(d:Domain) WITH s, d MATCH (s)-[r:MemberOf|GetChangesAll*1..]->(d) WITH s, d MATCH p = (s)-[r:MemberOf|GetChanges|GetChangesAll*1..]->(d) AND a.highvalue = false SET s.highvalue = true, s.highvaluereason = 'DCSync Principal' RETURN p"
                 }
             ]
         },
@@ -265,7 +283,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH p = (d:Domain)-[r:Contains*1..]->(uc) WHERE (uc:User OR uc:Computer) AND uc.unconstraineddelegation = true SET uc.highvalue = true, uc.highvaluereason = 'Unconstrained Delegation Principal' RETURN p"
+                    "query": "MATCH p = (d:Domain)-[r:Contains*1..]->(uc) WHERE (uc:User OR uc:Computer) AND uc.unconstraineddelegation = true AND a.highvalue = false SET uc.highvalue = true, uc.highvaluereason = 'Unconstrained Delegation Principal' RETURN p"
                 }
             ]
         },
@@ -274,7 +292,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (a)-[r:AdminTo|ForceChangePassword]->(b) SET a.highvalue = true, a.highvaluereason = 'Local Admin or Reset Password Principal' RETURN a"
+                    "query": "MATCH (a)-[r:AdminTo|ForceChangePassword]->(b) AND a.highvalue = false SET a.highvalue = true, a.highvaluereason = 'Local Admin or Reset Password Principal' RETURN a"
                 }
             ]
         },
@@ -283,7 +301,16 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (a)-[r:AllowedToDelegate|ExecuteDCOM|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner]->(n:Computer) SET a.highvalue = true, a.highvaluereason = 'Principal with Privileges on Computers' RETURN a"
+                    "query": "MATCH (a)-[r:AllowedToDelegate|ExecuteDCOM|ForceChangePassword|GenericAll|GenericWrite|Owns|WriteDacl|WriteOwner]->(n:Computer) AND a.highvalue = false SET a.highvalue = true, a.highvaluereason = 'Principal with Privileges on Computers' RETURN a"
+                }
+            ]
+        },
+        {
+            "name": "Set Principals with Privileges on Cert Publishers as High Value Targets",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH (a)-[r:GenericAll|GenericWrite|MemberOf|Owns|WriteDacl|WriteOwner]->(g:Group) WHERE g.objectid =~ 'S-1-5-21-.*-517' AND a.highvalue = false SET a.highvalue = true, a.highvaluereason = 'Principal with Privileges on the Cert Publisher group' RETURN a"
                 }
             ]
         },


### PR DESCRIPTION
Added queries:
- Group Delegated Outbound Object Control of Owned Principals (https://twitter.com/n00py1/status/1483258257762406404)
- Find Dangerous Rights for Groups under Domain Users (https://twitter.com/n00py1/status/1483258660507824131)
- Set Principals with Privileges on Cert Publishers as High Value Targets

Fixed:
- Overwriting highvaluereason when setting highvalue on objects already in high value