### PR TITLE
Add capability to create new edges

### DIFF
--- a/BloodHoundLoader.py
+++ b/BloodHoundLoader.py
@@ -18,6 +18,7 @@ parser.add_argument('--dbpassword', dest = 'databasePassword', help = 'Database 
 group = parser.add_mutually_exclusive_group(required = True)
 group.add_argument('-m', '--mode', dest = 'mode', help = 'Mode, h = set to high value, o = set to owned, s = set to no SMB signing', choices = ['h', 'o', 's'])
 group.add_argument('-o', '--operation', dest = 'operation', help = 'Operation to perform if the mode is not set, for instance "highvalue = true"')
+group.add_argument('-e', '--edge', dest = 'edge', help = 'Create the provided edge, file must contain exactly 2 nodes per line, comma separated')
 parser.add_argument('-c', '--comment', dest = 'comment', help = 'Comment for the log', default = '')
 parser.add_argument('-v', '--verbose', dest = 'verbose', help = 'Verbose mode', action = 'store_true')
 parser.add_argument('filePaths', nargs = '+', help = 'Paths of files the to import')
@@ -40,6 +41,8 @@ elif arguments.mode == 'o':
     operation = 'owned = true'
 elif arguments.mode == 's':
     operation = 'hassigning = false'
+elif not arguments.edge is None:
+    operation = 'edge'
 else:
     operation = arguments.operation
 
@@ -53,23 +56,44 @@ try:
                 logger.info('[*] Opened file: ' + filePath)
 
                 for line in file:
-                    item = line.strip()
-                    logger.debug('[*] Current item: ' + item)
+                    if operation == 'edge':
+                        item = line.strip().split(',')
+                        logger.debug('[*] Current item: ' + item[0] + ' ' + item[1])
 
-                    if item:
-                        name = item.upper()
+                        if item[0] and item[1]:
+                            source = item[0].upper()
+                            destination = item[1].upper()
 
-                        log = '(file: ' + filePath + ', comment: ' + arguments.comment + ')'
-                        query = 'MATCH (a {name: $name}) SET a.' + operation + ', a.BloodHoundLoaderLog = $log RETURN COUNT(*) AS count'
-                        results = session.run(query, name = name, log = log)
+                            log = '(file: ' + filePath + ', comment: ' + arguments.comment + ')'
+                            query = 'MATCH (s),(d) WHERE s.name = "' + source + '" AND d.name = "' + destination + '" CREATE (s)-[r:' + arguments.edge + ']->(d) SET r.BloodHoundLoaderLog = "' + log + '" RETURN COUNT(*) AS count'
+                            logger.debug('[*] Query: ' + query)
+                            results = session.run(query)
 
-                        count = results.single()['count']
-                        if count > 0:
-                            logger.info('[+] Modified: ' + item)
-                            logger.debug('[*] Number of modified entries: ' + str(count))
-                            logger.debug('[*] Stored message: ' + log)
-                        else:
-                            logger.error('[-] Could not modify: ' + item)
+                            count = results.single()['count']
+                            if count > 0:
+                                logger.info('[+] Created: ' +  source + ' - ' + arguments.edge + ' -> ' + destination)
+                                logger.debug('[*] Number of modified entries: ' + str(count))
+                                logger.debug('[*] Stored message: ' + log)
+                            else:
+                                logger.error('[-] Could not create: ' + source + ' - ' + arguments.edge + ' -> ' + destination)
+                    else:
+                        item = line.strip()
+                        logger.debug('[*] Current item: ' + item)
+
+                        if item:
+                            name = item.upper()
+
+                            log = '(file: ' + filePath + ', comment: ' + arguments.comment + ')'
+                            query = 'MATCH (a {name: $name}) SET a.' + operation + ', a.BloodHoundLoaderLog = $log RETURN COUNT(*) AS count'
+                            results = session.run(query, name = name, log = log)
+
+                            count = results.single()['count']
+                            if count > 0:
+                                logger.info('[+] Modified: ' + item)
+                                logger.debug('[*] Number of modified entries: ' + str(count))
+                                logger.debug('[*] Stored message: ' + log)
+                            else:
+                                logger.error('[-] Could not modify: ' + item)
 
 except ServiceUnavailable:
     logger.exception('[-] Connection to BloodHound Neo4j database failed')

--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ COMPUTER.ACME.COM
 GUEST@ACME.COM
 ```
 
+Create new AdminTo edges based on the tuples in the file "adminto.txt":
+```
+python3 BloodHoundLoader.py --edge AdminTo adminto.txt
+```
+
+The names tuples in the text file must be comma separated and ordered (source,destination):
+```
+DOMAIN ADMINS@ACME.COM,DC.ACME.COM
+SERVER ADMINS@ACME.COM,COMPUTER1.ACME.COM
+EDWARD.NIGMA@ACME.COM,RIDDLE.ACME.COM
+```
+
 Full help:
 ```
 python3 BloodHoundLoader.py --help
@@ -258,6 +270,8 @@ optional arguments:
                         Mode, h = set to high value, o = set to owned, s = set to no SMB signing (default: None)
   -o OPERATION, --operation OPERATION
                         Operation to perform if the mode is not set, for instance "highvalue = true" (default: None)
+  -e EDGE, --edge EDGE
+                        Create the provided edge, file must contain exactly 2 nodes per line, comma separated (default: None)
   -c COMMENT, --comment COMMENT
                         Comment for the log (default: )
   -v, --verbose         Verbose mode (default: False)


### PR DESCRIPTION
With some small modifications you can now add new edges. A use case would be that you have a central system applying local admin permissions to all the servers. If you can get an export of this data it's now easy to add it to the DB and increase the number of attack paths in the graph. 