### PR TITLE
[chore] fix image link

### DIFF
--- a/BloodHound_Custom_Queries_Merger/README.md
+++ b/BloodHound_Custom_Queries_Merger/README.md
@@ -32,7 +32,7 @@ cp customqueries.json ~/.config/bloodhound/customqueries.json
 
 You will find the custom queries in BloodHound:
 
-![Merged BloodHound Custom Queries](bloodhound_queries.png
+![Merged BloodHound Custom Queries](bloodhound_queries.png)
 
 ## Alternative
 


### PR DESCRIPTION
the parenthesis was removed in https://github.com/CompassSecurity/BloodHoundQueries/commit/d5298bde9d126222f8d20251ca06fbd8334813af